### PR TITLE
jenkins: adds -a flag in order to show ALL containers, even the not running ones

### DIFF
--- a/pipeline/JenkinsfileDev.groovy
+++ b/pipeline/JenkinsfileDev.groovy
@@ -13,7 +13,7 @@ pipeline {
         stage ("Restarting docker container") {
             steps {
                 echo "Step: Stopping current container"
-                sh 'test ! -z "`docker ps | grep sinamecc_frontend_dev`" && (docker stop sinamecc_frontend_dev && docker rm sinamecc_frontend_dev) || echo "sinamecc_frontend_dev does not exists"'
+                sh 'test ! -z "`docker ps -a | grep sinamecc_frontend_dev`" && (docker stop sinamecc_frontend_dev && docker rm sinamecc_frontend_dev) || echo "sinamecc_frontend_dev does not exists"'
 
                 echo "Step: Running new container"
                 sh 'docker run -d --name sinamecc_frontend_dev -p 8016:80 sinamecc_frontend:dev'


### PR DESCRIPTION
## Summary

Checking last Jenkins build logs, they say that there is a container still running with the name of `sinamecc_frontend_dev`.

The command we use to assert if there are running docker images misses a `-a`.
