### PR TITLE
SIN-I70-I74-I77

### DIFF
--- a/src/app/mitigation-actions/comments-structure.ts
+++ b/src/app/mitigation-actions/comments-structure.ts
@@ -133,7 +133,7 @@ export const commentsStructureModule5: CommentsStructure[] = [
     module: 'mitigationAction.indicatorDataSource',
     fields: [
       'mitigationAction.responsibleInstitution',
-      'mitigationAction.sourceType',
+      'mitigationAction.dataEntryMonitoring',
       'general.other',
       'mitigationAction.statisticalOperationName',
     ],
@@ -175,7 +175,7 @@ export const commentsStructureModule6: CommentsStructure[] = [
       'mitigationAction.reportingPeriod',
       'general.until',
       'mitigationAction.indicatorDataUpdateDate',
-      'mitigationAction.sourceType',
+      'mitigationAction.dataEntryMonitoring',
     ],
   },
   {

--- a/src/app/mitigation-actions/emissions-mitigation-form/emissions-mitigation-form.component.html
+++ b/src/app/mitigation-actions/emissions-mitigation-form/emissions-mitigation-form.component.html
@@ -145,8 +145,8 @@
             </mat-form-field>
             <br />
 
-            <div class="flex flex-row justify-center">
-              <mat-form-field class="field-ppcn">
+            <div class="flex flex-col xl:flex-row gap-1 xl:gap-6 justify-center w-full">
+              <mat-form-field class="field-ppcn w-full xl:flex-1 min-w-[250px] mb-0 xl:mb-0">
                 <mat-label translate
                   >4.1.7 -
                   <span translate
@@ -160,6 +160,7 @@
                 type="file"
                 accept="zip,application/octet-stream,application/zip,application/x-zip,application/x-zip-compressed,application/pdf,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet, application/vnd.ms-excel,application/msword,"
                 name="impact-documentation"
+                class="block w-full xl:w-auto mb-4"
                 (change)="uploadFile($event)"
               />
               <br />

--- a/src/app/mitigation-actions/impact-form/impact-form.component.html
+++ b/src/app/mitigation-actions/impact-form/impact-form.component.html
@@ -78,22 +78,7 @@
                   <mat-radio-button [style.margin.px]="5" value="BIANNUAL">
                     <label translate>general.biannual</label>
                   </mat-radio-button>
-                  <mat-radio-button [style.margin.px]="5" value="QUARTERLY">
-                    <label translate>general.quarterly</label>
-                  </mat-radio-button>
-                  <mat-radio-button [style.margin.px]="5" value="OTHER">
-                    <label translate>general.other</label>
-                  </mat-radio-button>
                 </mat-radio-group>
-              </div>
-
-              <div *ngIf="indicatorReportingPeriodicity.value === 'OTHER'">
-                <mat-form-field class="field-ppcn">
-                  <mat-label translate>5.1.5 - <span translate>general.other</span></mat-label>
-                  <input matInput formControlName="indicatorReportingPeriodicityOtherCtrl" />
-                  <mat-error translate>errorLabel.fieldRequired</mat-error>
-                </mat-form-field>
-                <br />
               </div>
 
               <div class="flex flex-row justify-center">

--- a/src/app/mitigation-actions/impact-form/impact-form.component.html
+++ b/src/app/mitigation-actions/impact-form/impact-form.component.html
@@ -44,15 +44,20 @@
               </mat-form-field>
               <br />
 
-              <div class="flex flex-row justify-center">
-                <mat-form-field class="field-ppcn">
+              <div class="flex flex-col xl:flex-row gap-1 xl:gap-6 justify-center w-full">
+                <mat-form-field class="field-ppcn w-full xl:flex-1 min-w-[250px] mb-0 xl:mb-0">
                   <mat-label translate
                     >5.1.4 - <span translate>mitigationAction.methodologicalDetailIndicator</span></mat-label
                   >
                   <input matInput formControlName="methodologicalDetailIndicatorCtrl" />
                   <mat-error translate>errorLabel.fieldRequired</mat-error>
                 </mat-form-field>
-                <input type="file" name="methodologicalDetailIndicatorFile" (change)="uploadFile($event)" />
+                <input
+                  type="file"
+                  name="methodologicalDetailIndicatorFile"
+                  (change)="uploadFile($event)"
+                  class="block w-full xl:w-auto mb-4 mt-6"
+                />
                 <br />
               </div>
 
@@ -172,15 +177,20 @@
                 <mat-error translate>errorLabel.fieldRequired</mat-error>
               </mat-form-field>
 
-              <div class="flex flex-row justify-center">
-                <mat-form-field class="field-ppcn">
+              <div class="flex flex-col xl:flex-row gap-1 xl:gap-6 justify-center w-full">
+                <mat-form-field class="field-ppcn w-full xl:flex-1 min-w-[250px] mb-0 xl:mb-0">
                   <mat-label translate
                     >5.1.10 - <span translate>mitigationAction.howSustainabilityIndicator</span></mat-label
                   >
                   <input matInput formControlName="howSustainabilityIndicatorCtrl" />
                   <mat-error translate>errorLabel.fieldRequired</mat-error>
                 </mat-form-field>
-                <input type="file" name="howSustainabilityIndicatorFile" (change)="uploadFile($event)" />
+                <input
+                  class="block w-full xl:w-auto mb-4"
+                  type="file"
+                  name="howSustainabilityIndicatorFile"
+                  (change)="uploadFile($event)"
+                />
                 <br />
               </div>
 

--- a/src/app/mitigation-actions/initiative-form/initiative-form.component.html
+++ b/src/app/mitigation-actions/initiative-form/initiative-form.component.html
@@ -52,9 +52,9 @@
               <mat-error translate>errorLabel.fieldRequired</mat-error>
             </mat-form-field>
 
-            <div class="flex flex-row justify-center">
-              <mat-form-field class="field-ppcn">
-                <mat-label translate>1.1.4 - <span translate>specificLabel.initiativeDescription</span></mat-label>
+            <div class="flex flex-col xl:flex-row gap-1 xl:gap-6 justify-center w-full">
+              <mat-form-field class="field-ppcn w-full xl:flex-1 min-w-[250px] mb-0 xl:mb-0">
+                <mat-label translate> 1.1.4 - <span translate>specificLabel.initiativeDescription</span> </mat-label>
                 <textarea
                   matInput
                   formControlName="initiativeDescriptionCtrl"
@@ -64,8 +64,9 @@
                 ></textarea>
                 <mat-error translate>errorLabel.fieldRequired</mat-error>
               </mat-form-field>
-              <input type="file" name="initiative" (change)="uploadFile($event)" />
+              <input type="file" name="initiative" (change)="uploadFile($event)" class="block w-full xl:w-auto mb-4" />
             </div>
+
             <div>
               <mat-form-field class="field-ppcn">
                 <mat-label translate>1.1.5 - <span translate>specificLabel.initiativeGoal</span></mat-label>
@@ -293,8 +294,8 @@
               </mat-radio-group>
             </div>
 
-            <div class="flex flex-row justify-center">
-              <mat-form-field class="field-ppcn">
+            <div class="flex flex-col xl:flex-row gap-1 xl:gap-6 justify-center w-full">
+              <mat-form-field class="field-ppcn w-full xl:flex-1 min-w-[250px] mb-0 xl:mb-0">
                 <mat-label translate>1.4.2 - <span translate>general.locationAction</span></mat-label>
                 <textarea
                   matInput
@@ -305,7 +306,12 @@
                 ></textarea>
                 <mat-error translate>errorLabel.fieldRequired</mat-error>
               </mat-form-field>
-              <input type="file" name="geographic-location" (change)="uploadFile($event)" />
+              <input
+                type="file"
+                name="geographic-location"
+                (change)="uploadFile($event)"
+                class="block w-full xl:w-auto mb-4"
+              />
             </div>
 
             <div class="box-button">

--- a/src/app/mitigation-actions/key-aspects-form/key-aspects-form.component.html
+++ b/src/app/mitigation-actions/key-aspects-form/key-aspects-form.component.html
@@ -28,8 +28,8 @@
             </mat-form-field>
             <br />
 
-            <div class="flex flex-row justify-center">
-              <mat-form-field class="field-ppcn">
+            <div class="flex flex-col xl:flex-row gap-1 xl:gap-6 justify-center w-full">
+              <mat-form-field class="field-ppcn w-full xl:flex-1 min-w-[250px] mb-0 xl:mb-0">
                 <mat-label translate
                   >3.1.2 - <span translate>mitigationAction.graphicLogicImpactEmissionsRemovals</span></mat-label
                 >
@@ -46,6 +46,7 @@
                 type="file"
                 accept=".rar,application/pdf,.zip"
                 name="ghg-information"
+                class="block w-full xl:w-auto mb-4 mt-6"
                 (change)="uploadFile($event)"
               />
               <br />

--- a/src/app/mitigation-actions/mitigation-action-form-flow/mitigation-action-form-flow.component.html
+++ b/src/app/mitigation-actions/mitigation-action-form-flow/mitigation-action-form-flow.component.html
@@ -1,12 +1,12 @@
 <div *ngIf="!isLoading" class="container-custom">
   <mat-card>
-    <h3>
-      <mat-card-title>
+    <div class="w-full flex flex-col content-center justify-center">
+      <h3 class="mb-4 mt-4 text-center">
         <span class="section-heading" translate>{{ title }}</span>
-        <mat-divider class="divider-custom"></mat-divider>
-        <mat-divider class="divider-custom"></mat-divider>
-      </mat-card-title>
-    </h3>
+      </h3>
+      <mat-divider class="divider-custom"></mat-divider>
+      <mat-divider class="divider-custom"></mat-divider>
+    </div>
 
     <form [formGroup]="mainGroup">
       <!-- {{!isLinear ? 'Enable linear mode' : 'Disable linear mode'}} -->
@@ -153,14 +153,7 @@
           ></app-reporting-climate-action-form>
         </mat-step>
       </mat-horizontal-stepper>
-      <!-- <div class="margin-20">
-            <div>form main group details:-</div>
-            <pre>Is mainGroup valid?: <br />{{mainGroup.valid | json}}</pre>
-            <pre>form value: <br />{{mainGroup.value | json}}</pre>
-
-        </div> -->
     </form>
-    <!-- </div> -->
   </mat-card>
 </div>
 

--- a/src/app/mitigation-actions/mitigation-action/mitigation-action.component.html
+++ b/src/app/mitigation-actions/mitigation-action/mitigation-action.component.html
@@ -625,7 +625,7 @@
               }}
             </h3>
             <h3 class="mat-h3">
-              <strong translate>mitigationAction.sourceType</strong>
+              <strong translate>mitigationAction.dataEntryMonitoring</strong>
               {{
                 mitigationAction?.monitoring_reporting_indicator?.monitoring_indicator
                   ? (mitigationAction?.monitoring_reporting_indicator?.monitoring_indicator)[0]?.updated_data

--- a/src/app/mitigation-actions/reporting-climate-action-form/reporting-climate-action-form.component.html
+++ b/src/app/mitigation-actions/reporting-climate-action-form/reporting-climate-action-form.component.html
@@ -114,7 +114,7 @@
 
             <div>
               <label class="radio-grup-label" translate
-                >6.2.1.3 - <span translate>mitigationAction.sourceType</span></label
+                >6.2.1.3 - <span translate>mitigationAction.dataEntryMonitoring</span></label
               ><br />
               <mat-radio-group
                 formControlName="reportTypeCtrl"
@@ -122,7 +122,7 @@
                 class="custom-radio-group"
               >
                 <mat-radio-button [style.margin.px]="5" [value]="1">
-                  <label translate>Línea de texto para el reporte</label>
+                  <label translate>Dato de monitoreo</label>
                 </mat-radio-button>
                 <mat-radio-button [style.margin.px]="5" [value]="2">
                   <label translate>Carga de documento</label>
@@ -137,7 +137,7 @@
             <div *ngIf="informationToUpdate.value === 1 || informationToUpdate.value === 3">
               <mat-form-field [style.margin-right]="'10px'" [style.width.%]="100" class="ppcn-field">
                 <mat-label translate
-                  >6.2.1.3 - <span translate>mitigationAction.sourceType</span>
+                  >6.2.1.3 - <span translate>mitigationAction.dataEntryMonitoring</span>
                   {{ informationToUpdate.value === 3 ? '- Webservice' : '' }}
                 </mat-label>
                 <input type="text" matInput formControlName="informationToUpdateCtrl" required />

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -144,7 +144,8 @@
     "addReviewMA": "Add a new review for this mitigation action",
     "descriptionReviewMA": "Description of the review of the Mitigation Action",
     "changelogMA": "Changelog for mitigation action",
-    "MAt": "MITIGATIONS ACTIONS"
+    "MAt": "MITIGATIONS ACTIONS",
+    "dataEntryMonitoring": "Data entry monitoring"
   },
 
   "reportData": {

--- a/src/translations/es-CR.json
+++ b/src/translations/es-CR.json
@@ -144,7 +144,8 @@
     "addReviewMA": "Agregar una nueva revisión para esta acción de mitigación",
     "descriptionReviewMA": "Descripción de la revisión de la Acción de Mitigación",
     "changelogMA": "Historial de cambios de la revision para la acción de mitigación",
-    "MAt": "ACCIONES DE MITIGACIÓN"
+    "MAt": "ACCIONES DE MITIGACIÓN",
+    "dataEntryMonitoring": "Ingreso de datos de monitoreo"
   },
 
   "reportData": {


### PR DESCRIPTION
# Summary

- Changes were made to the MA module tags.
- Responsiveness view in the Input File field.
- Some options were removed from the selectors.

**_Fixes # [SIN-I70](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I70)_**
**_Fixes # [SIN-I74](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I74)_**
**_Fixes # [SIN-I77](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I77)_**


## Description

- Changes were made to the MA module tags.
- Responsiveness view in the Input File field.
- Some options were removed from the selectors.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

<img width="1104" alt="Captura de pantalla 2025-05-20 a la(s) 3 41 10 p  m" src="https://github.com/user-attachments/assets/0a6202e8-90c0-4c46-98af-4512fda81d2c" />
<img width="714" alt="Captura de pantalla 2025-05-20 a la(s) 3 39 28 p  m" src="https://github.com/user-attachments/assets/22d28f46-0b60-43ba-b038-7d076fa1d33b" />
<img width="849" alt="Captura de pantalla 2025-05-20 a la(s) 3 23 33 p  m" src="https://github.com/user-attachments/assets/d9818c30-f284-445b-9f05-6a6526e43e9e" />
<img width="853" alt="Captura de pantalla 2025-05-20 a la(s) 3 23 01 p  m" src="https://github.com/user-attachments/assets/3954923b-a0e1-45bf-8eaa-5691e800b3c3" />
<img width="1109" alt="Captura de pantalla 2025-05-20 a la(s) 3 21 40 p  m" src="https://github.com/user-attachments/assets/6ad90fea-cfd1-4464-be23-2c4914b7bcf3" />

