### PR TITLE
[SIN-I69][SIN-I68]  fix: restrict max digit of decimal in amount

### DIFF
--- a/src/app/@shared/validators.ts
+++ b/src/app/@shared/validators.ts
@@ -1,0 +1,8 @@
+import { AbstractControl, ValidationErrors } from '@angular/forms';
+
+export function twoDecimalPlacesValidator(control: AbstractControl): ValidationErrors | null {
+  const value = control.value;
+  if (value === null || value === '') return null;
+  const regex = /^\d+(\.\d{1,2})?$/;
+  return regex.test(value) ? null : { decimal: 'two decimal places' };
+}

--- a/src/app/@shared/validators.ts
+++ b/src/app/@shared/validators.ts
@@ -1,8 +1,0 @@
-import { AbstractControl, ValidationErrors } from '@angular/forms';
-
-export function twoDecimalPlacesValidator(control: AbstractControl): ValidationErrors | null {
-  const value = control.value;
-  if (value === null || value === '') return null;
-  const regex = /^\d+(\.\d{1,2})?$/;
-  return regex.test(value) ? null : { decimal: 'two decimal places' };
-}

--- a/src/app/mitigation-actions/basic-information-form/basic-information-form.component.html
+++ b/src/app/mitigation-actions/basic-information-form/basic-information-form.component.html
@@ -123,7 +123,7 @@
 
                   <mat-form-field [style.margin-right]="'10px'" [style.width.%]="100" class="ppcn-field">
                     <mat-label translate>2.1.3 - <span translate>general.amount</span></mat-label>
-                    <input type="number" matInput formControlName="mitigationActionAmounttCtrl" required />
+                    <input type="number" matInput formControlName="mitigationActionAmounttCtrl" required step=".01" />
                     <mat-error translate>errorLabel.fieldRequired</mat-error>
                   </mat-form-field>
 

--- a/src/app/mitigation-actions/basic-information-form/basic-information-form.component.html
+++ b/src/app/mitigation-actions/basic-information-form/basic-information-form.component.html
@@ -123,7 +123,7 @@
 
                   <mat-form-field [style.margin-right]="'10px'" [style.width.%]="100" class="ppcn-field">
                     <mat-label translate>2.1.3 - <span translate>general.amount</span></mat-label>
-                    <input type="number" matInput formControlName="mitigationActionAmounttCtrl" required step=".01" />
+                    <input type="text" matInput formControlName="mitigationActionAmounttCtrl" required step=".01" />
                     <mat-error translate>errorLabel.fieldRequired</mat-error>
                   </mat-form-field>
 

--- a/src/app/mitigation-actions/basic-information-form/basic-information-form.component.ts
+++ b/src/app/mitigation-actions/basic-information-form/basic-information-form.component.ts
@@ -12,7 +12,6 @@ import { MitigationAction } from '../mitigation-action';
 import { ErrorReportingComponent } from '@shared';
 import { DatePipe } from '@angular/common';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { twoDecimalPlacesValidator } from '@app/@shared/validators';
 
 const log = new Logger('MitigationAction');
 
@@ -147,7 +146,7 @@ export class BasicInformationFormComponent implements OnInit {
         currencyValueCtrl: [element.currency],
         mitigationActionAmounttCtrl: [
           element.budget,
-          [Validators.required, Validators.maxLength(50), twoDecimalPlacesValidator],
+          [Validators.required, Validators.pattern('^\\d{1,18}(\\.\\d{1,2})?$')],
         ],
         referenceYearCtrl: [element.reference_year, Validators.required],
       });

--- a/src/app/mitigation-actions/basic-information-form/basic-information-form.component.ts
+++ b/src/app/mitigation-actions/basic-information-form/basic-information-form.component.ts
@@ -12,6 +12,7 @@ import { MitigationAction } from '../mitigation-action';
 import { ErrorReportingComponent } from '@shared';
 import { DatePipe } from '@angular/common';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { twoDecimalPlacesValidator } from '@app/@shared/validators';
 
 const log = new Logger('MitigationAction');
 
@@ -144,7 +145,10 @@ export class BasicInformationFormComponent implements OnInit {
         id: [element.id],
         mitigationActionDescriptionCtrl: [element.source_description, [Validators.required, Validators.maxLength(300)]],
         currencyValueCtrl: [element.currency],
-        mitigationActionAmounttCtrl: [element.budget, [Validators.required, Validators.maxLength(50)]],
+        mitigationActionAmounttCtrl: [
+          element.budget,
+          [Validators.required, Validators.maxLength(50), twoDecimalPlacesValidator],
+        ],
         referenceYearCtrl: [element.reference_year, Validators.required],
       });
       index += 1;

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -112,7 +112,7 @@
     "nameRegisteredMideplan": "Under what name is the project registered in Mideplan?",
     "registeredNonReimbursableCooperationMideplan": "Is the action registered in the registry of non-reimbursable international cooperation projects of Mideplan?",
     "financedSourcesInternationalCooperation": "Acciones financiadas con fuentes de cooperación internacional",
-    "referenceYear": "reference year",
+    "referenceYear": "Reference year",
     "emissionSourceSector": "Emission source sector",
     "mitigationActionBudget": "Description of the funding source",
     "financingSourceApplying": "Describe the financing source to which you are applying",

--- a/src/translations/es-CR.json
+++ b/src/translations/es-CR.json
@@ -112,7 +112,7 @@
     "nameRegisteredMideplan": "¿Bajo que nombre se encuentra el proyecto registrado en Mideplan?",
     "registeredNonReimbursableCooperationMideplan": "¿Se encuentra la acción registrada en el registro de proyectos de cooperación internacional no reembolsable de Mideplan?",
     "financedSourcesInternationalCooperation": "Acciones financiadas con fuentes de cooperación internacional",
-    "referenceYear": "Año de refencia",
+    "referenceYear": "Año de referencia",
     "emissionSourceSector": "Sector fuente de emisiones",
     "mitigationActionBudget": "Descripción de la fuente de financiamiento",
     "financingSourceApplying": "Describa la fuente financiamiento a la que está aplicando",


### PR DESCRIPTION
# Summary

Fixed typo and decimals in amount

**_Fixes # [I69](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I69)_**
**_Fixes # [I69](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I68)_**

## Description

- Fixed typo
- added validator for amount

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:

<img width="786" alt="Screenshot 2025-05-23 at 14 47 30" src="https://github.com/user-attachments/assets/eee7756f-8b9d-4362-bab9-73237095459f" />
<img width="786" alt="Screenshot 2025-05-23 at 14 47 47" src="https://github.com/user-attachments/assets/28aeec0a-3821-4915-8a17-7ee58eb662ca" />

