### PR TITLE
SIN-I73

### DIFF
--- a/src/app/@core/http/error-handler.interceptor.ts
+++ b/src/app/@core/http/error-handler.interceptor.ts
@@ -6,6 +6,7 @@ import { catchError } from 'rxjs/operators';
 import { environment } from '@env/environment';
 import { Logger } from '@core/logger.service';
 import { Router } from '@angular/router';
+import { CredentialsService } from '@app/auth';
 
 const log = new Logger('ErrorHandlerInterceptor');
 
@@ -14,7 +15,10 @@ const log = new Logger('ErrorHandlerInterceptor');
  */
 @Injectable()
 export class ErrorHandlerInterceptor implements HttpInterceptor {
-  constructor(private router: Router) {}
+  constructor(
+    private router: Router,
+    private service: CredentialsService,
+  ) {}
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(request).pipe(catchError((error) => this.errorHandler(error)));
@@ -24,6 +28,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
   private errorHandler(response: HttpEvent<any>): Observable<HttpEvent<any>> {
     if (response instanceof HttpErrorResponse) {
       if (401 === response.status) {
+        this.service.setCredentials();
         this.router.navigate(['/login'], { replaceUrl: true });
       }
     }

--- a/src/app/mitigation-actions/impact-form/impact-form.component.ts
+++ b/src/app/mitigation-actions/impact-form/impact-form.component.ts
@@ -8,7 +8,7 @@ import { MitigationActionsService } from '@app/mitigation-actions/mitigation-act
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { MitigationActionNewFormData } from '@app/mitigation-actions/mitigation-action-new-form-data';
-import { MAFile, MitigationAction } from '../mitigation-action';
+import { MAFile, MitigationAction, States } from '../mitigation-action';
 import { ErrorReportingComponent } from '@shared';
 import { DatePipe } from '@angular/common';
 import { I18nService } from '@app/i18n';
@@ -30,6 +30,7 @@ export class ImpactFormComponent implements OnInit {
   wasSubmittedSuccessfully = false;
   startDate = new Date();
   mitigationAction: MitigationAction;
+  @Output() state = new EventEmitter<States>();
 
   files: {
     methodologicalDetail: MAFile;
@@ -85,6 +86,7 @@ export class ImpactFormComponent implements OnInit {
       this.service.currentMitigationAction.subscribe((message) => {
         this.mitigationAction = message;
         this.updateFormData();
+        this.state.emit(this.mitigationAction.fsm_state.state as States);
       });
     }
   }
@@ -304,6 +306,7 @@ export class ImpactFormComponent implements OnInit {
         .subscribe(
           (response) => {
             this.successSendForm(response.id);
+            this.state.emit(response.state as States);
           },
           (error) => {
             this.translateService.get('Error submitting form').subscribe((res: string) => {
@@ -331,7 +334,9 @@ export class ImpactFormComponent implements OnInit {
       this.snackBar.open(res, null, { duration: 3000 });
     });
     this.wasSubmittedSuccessfully = true;
-    this.stepper.next();
+    setTimeout(() => {
+      this.router.navigate(['/mitigation/actions'], { replaceUrl: true });
+    }, 2000);
   }
 
   uploadFile(event: Event) {

--- a/src/app/mitigation-actions/initiative-form/initiative-form.component.ts
+++ b/src/app/mitigation-actions/initiative-form/initiative-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, Input } from '@angular/core';
+import { Component, OnInit, ViewChild, Input, EventEmitter, Output } from '@angular/core';
 import { Router } from '@angular/router';
 import { UntypedFormGroup, UntypedFormBuilder, Validators, AbstractControl, UntypedFormArray } from '@angular/forms';
 import { finalize, tap } from 'rxjs/operators';
@@ -8,7 +8,7 @@ import { MitigationActionsService } from '@app/mitigation-actions/mitigation-act
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { MitigationActionNewFormData, InitiativeType } from '@app/mitigation-actions/mitigation-action-new-form-data';
-import { MAFile, MitigationAction } from '../mitigation-action';
+import { MAFile, MitigationAction, States } from '../mitigation-action';
 import { ErrorReportingComponent } from '@shared';
 import { DatePipe } from '@angular/common';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -22,6 +22,7 @@ const log = new Logger('MitigationAction');
   standalone: false,
 })
 export class InitiativeFormComponent implements OnInit {
+  @Output() state = new EventEmitter<States>();
   version: string = environment.version;
   error: string;
   form: UntypedFormGroup;
@@ -137,6 +138,7 @@ export class InitiativeFormComponent implements OnInit {
       this.service.currentMitigationAction.subscribe((message) => {
         this.mitigationAction = message;
         this.updateFormData();
+        this.state.emit(this.mitigationAction.fsm_state.state as States);
       });
     }
   }
@@ -485,6 +487,7 @@ export class InitiativeFormComponent implements OnInit {
         .subscribe(
           (response) => {
             this.successSendForm(response.id);
+            this.state.emit(response.state as States);
           },
           (error) => {
             this.translateService.get('Error submitting form').subscribe((res: string) => {

--- a/src/app/mitigation-actions/key-aspects-form/key-aspects-form.component.ts
+++ b/src/app/mitigation-actions/key-aspects-form/key-aspects-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild, Input } from '@angular/core';
+import { Component, OnInit, ViewChild, Input, Output, EventEmitter } from '@angular/core';
 import { Router } from '@angular/router';
 import { UntypedFormGroup, UntypedFormBuilder, Validators, AbstractControl } from '@angular/forms';
 import { finalize } from 'rxjs/operators';
@@ -8,7 +8,7 @@ import { MitigationActionsService } from '@app/mitigation-actions/mitigation-act
 import { TranslateService } from '@ngx-translate/core';
 import { Observable } from 'rxjs';
 import { MitigationActionNewFormData } from '@app/mitigation-actions/mitigation-action-new-form-data';
-import { ImpactEmission, MAFile, MitigationAction } from '../mitigation-action';
+import { ImpactEmission, MAFile, MitigationAction, States } from '../mitigation-action';
 import { MomentDateAdapter } from '@angular/material-moment-adapter';
 
 import * as _moment from 'moment';
@@ -67,6 +67,7 @@ export class KeyAspectsFormComponent implements OnInit {
   @Input() newFormData: Observable<MitigationActionNewFormData>;
   @Input() processedNewFormData: MitigationActionNewFormData;
   @Input() isUpdating: boolean;
+  @Output() state = new EventEmitter<States>();
 
   @ViewChild('errorComponent') errorComponent: ErrorReportingComponent;
 
@@ -93,6 +94,7 @@ export class KeyAspectsFormComponent implements OnInit {
       this.service.currentMitigationAction.subscribe((message) => {
         this.mitigationAction = message;
         this.updateFormData();
+        this.state.emit(this.mitigationAction.fsm_state.state as States);
       });
     }
   }
@@ -160,6 +162,7 @@ export class KeyAspectsFormComponent implements OnInit {
       )
       .subscribe(
         (response) => {
+          this.state.emit(response.state as States);
           this.successSendForm(response.id);
         },
         (error) => {
@@ -183,6 +186,7 @@ export class KeyAspectsFormComponent implements OnInit {
       this.snackBar.open(res, null, { duration: 3000 });
     });
     this.wasSubmittedSuccessfully = true;
+
     this.stepper.next();
   }
 

--- a/src/app/mitigation-actions/mitigation-action-form-flow/mitigation-action-form-flow.component.html
+++ b/src/app/mitigation-actions/mitigation-action-form-flow/mitigation-action-form-flow.component.html
@@ -19,6 +19,7 @@
             [isUpdating]="isUpdating"
             [stepper]="stepper"
             [action]="action"
+            (state)="state = $event"
           ></app-initiative-form>
         </mat-step>
 
@@ -29,6 +30,7 @@
             [stepper]="stepper"
             [processedNewFormData]="processedNewFormData"
             [isUpdating]="isUpdating"
+            (state)="state = $event"
           >
           </app-basic-information-form>
 
@@ -61,6 +63,7 @@
             [newFormData]="newFormData"
             [processedNewFormData]="processedNewFormData"
             [isUpdating]="isUpdating"
+            (state)="state = $event"
           >
           </app-key-aspects-form>
 
@@ -93,6 +96,7 @@
             [processedNewFormData]="processedNewFormData"
             [isUpdating]="isUpdating"
             [stepper]="stepper"
+            (state)="state = $event"
           >
           </app-emissions-mitigation-form>
 
@@ -127,10 +131,11 @@
             [processedNewFormData]="processedNewFormData"
             [isUpdating]="isUpdating"
             [stepper]="stepper"
+            (state)="state = $event"
           >
           </app-impact-form>
 
-          <div class="align-right">
+          <div *ngIf="state === accepted" class="align-right">
             <button
               [disabled]="!impactForm?.wasSubmittedSuccessfully"
               (click)="stepper.next()"
@@ -142,7 +147,7 @@
           </div>
         </mat-step>
 
-        <mat-step formGroupName="5" [stepControl]="formArray?.get([5])">
+        <mat-step *ngIf="state === accepted" formGroupName="5" [stepControl]="formArray?.get([5])">
           <ng-template matStepLabel
             ><span translate>mitigationAction.monitoringReportingClimateActions</span>
           </ng-template>

--- a/src/app/mitigation-actions/mitigation-action-form-flow/mitigation-action-form-flow.component.ts
+++ b/src/app/mitigation-actions/mitigation-action-form-flow/mitigation-action-form-flow.component.ts
@@ -29,6 +29,7 @@ import { EmissionsMitigationFormComponent } from '@app/mitigation-actions/emissi
 import { ImpactFormComponent } from '@app/mitigation-actions/impact-form/impact-form.component';
 import { ReportingClimateActionFormComponent } from '../reporting-climate-action-form/reporting-climate-action-form.component';
 import { I18nService } from '@app/i18n';
+import { States } from '../mitigation-action';
 
 @Component({
   selector: 'app-mitigation-action-form-flow',
@@ -47,6 +48,8 @@ export class MitigationActionFormFlowComponent implements OnInit, AfterViewInit 
 
   @ViewChild(ReportingClimateActionFormComponent)
   reportingClimateFormComponent: ReportingClimateActionFormComponent;
+  state: States;
+  accepted = States.ACCEPTED_BY_DCC;
 
   @Input()
   title: string;
@@ -94,6 +97,7 @@ export class MitigationActionFormFlowComponent implements OnInit, AfterViewInit 
     this.isUpdating = this.action === 'update';
     this.isLinear = true;
     this.isLoading = false;
+    // this.state = this.initiativeForm ? this.initiativeForm
   }
 
   createForm() {

--- a/src/app/mitigation-actions/mitigation-action.ts
+++ b/src/app/mitigation-actions/mitigation-action.ts
@@ -32,7 +32,10 @@ export interface MitigationAction {
   next_state: NextState[];
   created: string;
   updated: string;
-  fsm_state: string;
+  fsm_state: {
+    state: string;
+    label: string;
+  };
   files: Files[];
   status_information: StatusInformation;
   geographic_location: GeographicLocation;
@@ -278,4 +281,16 @@ export interface MADataCatalogs {
 export interface MAFile {
   file: File;
   name: string;
+}
+
+export enum States {
+  NEW = 'new',
+  SUBMITTED = 'submitted',
+  IN_EVALUATION_BY_DCC = 'in_evaluation_by_DCC',
+  REQUESTED_CHANGES_BY_DCC = 'requested_changes_by_DCC',
+  UPDATING_BY_REQUEST_DCC = 'updating_by_request_DCC',
+  ACCEPTED_BY_DCC = 'accepted_by_DCC',
+  REJECTED_BY_DCC = 'rejected_by_DCC',
+  REGISTERED_BY_DCC = 'registered_by_DCC',
+  END = 'end',
 }

--- a/src/app/mitigation-actions/mitigation-actions-list/mitigation-actions-list.component.ts
+++ b/src/app/mitigation-actions/mitigation-actions-list/mitigation-actions-list.component.ts
@@ -102,7 +102,7 @@ export class MitigationActionsListComponent implements OnInit {
     const selectedMitigationAction = this.dataSource.data.find((ma) => ma.id === uuid);
     const status = selectedMitigationAction.fsm_state;
 
-    const route = this.service.mapRoutesStatuses(uuid).find((x) => x.status === status);
+    const route = this.service.mapRoutesStatuses(uuid).find((x) => x.status === status.state);
     if (route) {
       this.router.navigate([route.route], { replaceUrl: true });
     } else {
@@ -162,7 +162,7 @@ export class MitigationActionsListComponent implements OnInit {
   }
 
   canChangeState(element: MitigationAction) {
-    if (element.fsm_state !== 'end') {
+    if (element.fsm_state.state !== 'end') {
       // is admin
       if (this.credentialsService.credentials.permissions.all) {
         return true;

--- a/src/app/mitigation-actions/mitigation-actions.service.ts
+++ b/src/app/mitigation-actions/mitigation-actions.service.ts
@@ -43,6 +43,7 @@ export interface Response {
   // Customize received credentials here
   statusCode: number;
   message: string;
+  state: string;
   id?: string;
 }
 
@@ -89,6 +90,7 @@ export class MitigationActionsService {
         const response = {
           statusCode: 200,
           message: 'Form submitted correctly',
+          state: body.fsm_state.state,
         };
         return response;
       }),
@@ -110,6 +112,7 @@ export class MitigationActionsService {
         const response = {
           statusCode: 200,
           id: body.id,
+          state: body.fsm_state.state,
           message: 'Form submitted correctly',
         };
         return response;


### PR DESCRIPTION


# Summary

Changed form registration step ending

**_Fixes # [SIN-I73](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I73)_**

## Description

- Hide section six of the MA form if the form has not been accepted.
- Ensure section six is only visible once the form is marked as accepted.
- Fixed an issue where login failed after a session timeout due to old/stale data in local storage interfering with re-authentication.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:


https://github.com/user-attachments/assets/a88cd521-bbb6-4753-8be8-dcfe92071788


