### PR TITLE
[SIN-I80] fix: Hide optional message when AA type is not A

### DIFF
--- a/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.html
+++ b/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.html
@@ -262,7 +262,10 @@
             >info</mat-icon
           >
         </ng-template>
-        <div class="my-2 flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200 p-2">
+        <div
+          *ngIf="type === types.A"
+          class="my-2 flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200 p-2"
+        >
           <span translate>general.optional</span>
         </div>
         <div class="finance-container flex flex-col justify-start items-start" formArrayName="themeCtrl">
@@ -351,7 +354,10 @@
         <ng-template matStepLabel>
           <span translate>adaptationAction.form2.relationshipInstruments</span>
         </ng-template>
-        <div class="my-2 flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200 p-2">
+        <div
+          *ngIf="type === types.A"
+          class="my-2 flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200 p-2"
+        >
           <span translate>general.optional</span>
         </div>
         <label translate>adaptationAction.form2.namePlanningInstrument</label>
@@ -521,7 +527,10 @@
         <ng-template matStepLabel>
           <span translate>adaptationAction.form2.implementation</span>
         </ng-template>
-        <div class="my-2 flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200 p-2">
+        <div
+          *ngIf="type === types.A"
+          class="my-2 flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200 p-2"
+        >
           <span translate>general.optional</span>
         </div>
         <mat-form-field class="field-ppcn">

--- a/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.ts
+++ b/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.ts
@@ -43,7 +43,8 @@ export class AdaptationActionsReportComponent implements OnInit {
   @Input() edit: boolean;
   durationInSeconds = 3;
   actualProvince = 0;
-
+  types = AAType;
+  type: AAType;
   provinces: Province[] = [];
   canton: Canton[] = [];
   districts: District[] = [];
@@ -213,8 +214,9 @@ export class AdaptationActionsReportComponent implements OnInit {
     section6.get('adaptationActionCodeCtrl').updateValueAndValidity();
   }
 
-  public changeAdaptationType(id: string) {
+  public changeAdaptationType(id: AAType) {
     this.onTypeSet.emit(id);
+    this.type = id;
     if (parseInt(id) === 1) {
       this.setOptionalValidators();
     } else {

--- a/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.ts
+++ b/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.ts
@@ -217,7 +217,7 @@ export class AdaptationActionsReportComponent implements OnInit {
   public changeAdaptationType(id: AAType) {
     this.onTypeSet.emit(id);
     this.type = id;
-    if (parseInt(id) === 1) {
+    if (id === this.types.A) {
       this.setOptionalValidators();
     } else {
       this.setRequiredValidators();


### PR DESCRIPTION
# Summary

Hide optional message when AA type is not A

**_Fixes # [SIN-I80](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I80/comments)_**

## Description

Hide optional message showing up when the selected AA type is not A as requested here by [this comment](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I80/comments/1846000001891183)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Evidence:


https://github.com/user-attachments/assets/fae4b3fe-02f1-40ee-8f3d-59fe512c2812

