### PR TITLE
100|105|111|112|113|114|116|103| Feat: enhance form usability with clarifications and field adjustments

### DIFF
--- a/src/app/adaptation-actions/adaptation-actions-action-impact/adaptation-actions-action-impact.component.html
+++ b/src/app/adaptation-actions/adaptation-actions-action-impact/adaptation-actions-action-impact.component.html
@@ -81,6 +81,7 @@
             <app-upload-button (fileChange)="uploadFile($event)" name="annexSupporting" />
             <br />
           </div>
+          <div class="text-sm text-gray-500" translate>general.requiredFile</div>
         </div>
 
         <div class="button-box flex flex-row justify-end items-center">

--- a/src/app/adaptation-actions/adaptation-actions-climate-monitoring/adaptation-actions-climate-monitoring.component.html
+++ b/src/app/adaptation-actions/adaptation-actions-climate-monitoring/adaptation-actions-climate-monitoring.component.html
@@ -218,6 +218,7 @@
                   <app-upload-button (fileChange)="uploadFile($event)" name="attachSupportMonitoring" />
                   <br />
                 </div>
+                <div class="text-sm text-gray-500" translate>general.requiredFile</div>
               </div>
 
               <div class="box-button">

--- a/src/app/adaptation-actions/adaptation-actions-financing/adaptation-actions-financing.component.html
+++ b/src/app/adaptation-actions/adaptation-actions-financing/adaptation-actions-financing.component.html
@@ -80,40 +80,43 @@
           <mat-error translate>errorLabel.fieldRequired</mat-error>
         </mat-form-field>
 
-        <div class="flex flex-row">
-          <div [style.margin-right]="'10px'">
-            <mat-button-toggle-group (change)="changeCurrency($event.value)" [value]="actualCurrency">
-              <mat-button-toggle value="CRC">CRC</mat-button-toggle>
-              <mat-button-toggle value="USD">USD</mat-button-toggle>
-              <mat-button-toggle value="other"><span translate>general.other</span></mat-button-toggle>
-            </mat-button-toggle-group>
+        <div class="flex flex-col">
+          <div class="flex flex-row">
+            <div [style.margin-right]="'10px'">
+              <mat-button-toggle-group (change)="changeCurrency($event.value)" [value]="actualCurrency">
+                <mat-button-toggle value="CRC">CRC</mat-button-toggle>
+                <mat-button-toggle value="USD">USD</mat-button-toggle>
+                <mat-button-toggle value="other"><span translate>general.other</span></mat-button-toggle>
+              </mat-button-toggle-group>
+            </div>
+
+            <mat-form-field
+              *ngIf="actualCurrency == 'other'"
+              [style.margin-right]="'10px'"
+              [style.width.%]="100"
+              class="ppcn-field"
+            >
+              <mat-label translate>general.currencyType</mat-label>
+              <input formControlName="adaptationActionFinancingBufgetOtherCtrl" type="text" matInput required />
+              <mat-error translate>errorLabel.fieldRequired</mat-error>
+            </mat-form-field>
+
+            <mat-form-field [style.margin-right]="'10px'" [style.width.%]="100" class="ppcn-field">
+              <mat-label translate>Presupuesto</mat-label>
+              <input type="text" matInput formControlName="adaptationActionFinancingBufgetValueCtrl" required />
+              <mat-error translate>errorLabel.fieldRequired</mat-error>
+            </mat-form-field>
+
+            <mat-form-field class="field-ppcn" appearance="fill">
+              <mat-label translate>mitigationAction.referenceYear</mat-label>
+              <mat-select formControlName="adaptationActionFinancingBufgetStarDateCtrl">
+                <mat-option *ngFor="let element of yearsArray" [value]="lastValidYear - element">
+                  <label translate>{{ lastValidYear - element }}</label>
+                </mat-option>
+              </mat-select>
+            </mat-form-field>
           </div>
-
-          <mat-form-field
-            *ngIf="actualCurrency == 'other'"
-            [style.margin-right]="'10px'"
-            [style.width.%]="100"
-            class="ppcn-field"
-          >
-            <mat-label translate>general.currencyType</mat-label>
-            <input formControlName="adaptationActionFinancingBufgetOtherCtrl" type="text" matInput required />
-            <mat-error translate>errorLabel.fieldRequired</mat-error>
-          </mat-form-field>
-
-          <mat-form-field [style.margin-right]="'10px'" [style.width.%]="100" class="ppcn-field">
-            <mat-label translate>Presupuesto</mat-label>
-            <input type="text" matInput formControlName="adaptationActionFinancingBufgetValueCtrl" required />
-            <mat-error translate>errorLabel.fieldRequired</mat-error>
-          </mat-form-field>
-
-          <mat-form-field class="field-ppcn" appearance="fill">
-            <mat-label translate>mitigationAction.referenceYear</mat-label>
-            <mat-select formControlName="adaptationActionFinancingBufgetStarDateCtrl">
-              <mat-option *ngFor="let element of yearsArray" [value]="lastValidYear - element">
-                <label translate>{{ lastValidYear - element }}</label>
-              </mat-option>
-            </mat-select>
-          </mat-form-field>
+          <div class="text-sm text-gray-500" translate>mitigationAction.referenceYearHint</div>
         </div>
 
         <div class="button-box flex flex-row justify-end items-center">

--- a/src/app/adaptation-actions/adaptation-actions-indicators/adaptation-actions-indicators.component.html
+++ b/src/app/adaptation-actions/adaptation-actions-indicators/adaptation-actions-indicators.component.html
@@ -158,21 +158,20 @@
               formControlName="adaptationActionIndicatorCoverageCtrl"
               class="custom-radio-group"
             >
-              <mat-radio-button value="NATIONAL">
-                <label translate>Nacional</label>
+              <mat-radio-button [value]="LOCATION.NATIONAL">
+                <label translate>adaptationAction.location.national</label>
               </mat-radio-button>
-              <mat-radio-button value="REGIONAL">
-                <label translate>Regional</label>
+              <mat-radio-button [value]="LOCATION.PROVINCIAL">
+                <label translate>adaptationAction.location.provincial</label>
               </mat-radio-button>
-              <mat-radio-button value="PROVINCIAL">
-                <label translate>Provincial</label>
+              <mat-radio-button [value]="LOCATION.CANTONAL">
+                <label translate>adaptationAction.location.cantonal</label>
               </mat-radio-button>
-              <mat-radio-button value="CANTONAL">
-                <label translate>Cantonal</label>
+              <mat-radio-button [value]="LOCATION.DISTRICT">
+                <label translate>adaptationAction.location.district</label>
               </mat-radio-button>
-
-              <mat-radio-button value="OTHER">
-                <label translate>Otro</label>
+              <mat-radio-button [value]="LOCATION.OTHER">
+                <label translate>adaptationAction.location.other</label>
               </mat-radio-button>
             </mat-radio-group>
 

--- a/src/app/adaptation-actions/adaptation-actions-indicators/adaptation-actions-indicators.component.ts
+++ b/src/app/adaptation-actions/adaptation-actions-indicators/adaptation-actions-indicators.component.ts
@@ -26,6 +26,14 @@ export class AdaptationActionsIndicatorsComponent implements OnInit {
   indicatorToolTipTxt =
     'Un indicador es una expresión cualitativa o cuantitativa, que es observable y permite describir las características de la realidad, a través de la evolución de una variable';
 
+  LOCATION = {
+    NATIONAL: 'NATIONAL',
+    PROVINCIAL: 'PROVINCIAL',
+    CANTONAL: 'CANTONAL',
+    DISTRICT: 'DISTRICT',
+    OTHER: 'OTHER',
+  };
+
   constructor(
     private formBuilder: UntypedFormBuilder,
     public snackBar: MatSnackBar,
@@ -153,7 +161,10 @@ export class AdaptationActionsIndicatorsComponent implements OnInit {
             adaptationActionIndicatorCoverageOtherCtrl: [''],
             adaptationActionIndicatorDisintegrationCtrl: [indicator.disaggregation, [Validators.maxLength(1000)]],
             adaptationActionIndicatorLimitCtrl: [indicator.limitation, [Validators.maxLength(1000)]],
-            adaptationActionIndicatorGoalCtrl: [indicator.associated_meta, [Validators.maxLength(100), Validators.required]],
+            adaptationActionIndicatorGoalCtrl: [
+              indicator.associated_meta,
+              [Validators.maxLength(100), Validators.required],
+            ],
             adaptationActionIndicatorMeasurementCtrl: [indicator.additional_information, [Validators.maxLength(1000)]],
             adaptationActionIndicatorDetailsCtrl: [indicator.comments, [Validators.maxLength(1000)]],
             indicatorBaselineCtrl: [indicator.indicator_base_line, [Validators.maxLength(500)]],

--- a/src/app/adaptation-actions/adaptation-actions-new/adaptation-actions-new.component.html
+++ b/src/app/adaptation-actions/adaptation-actions-new/adaptation-actions-new.component.html
@@ -10,32 +10,33 @@
       </mat-card-title>
     </div>
     <div class="p-2">
-      <div class="flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200 p-2">
-        <div class="flex flex-row justify-between w-full">
+      <div class="flex flex-col justify-center items-start rounded bg-gray-100 border-2 border-gray-200">
+        <div
+          class="flex flex-row justify-between w-full hover:cursor-pointer hover:bg-gray-200 rounded-sm p-2"
+          (click)="handleAssistantOpen()"
+        >
           <div translate>adaptationAction.help.title</div>
-          <div
-            mat-icon-button
-            (click)="handleAssistantOpen()"
-            class="h-6 w-6 min-w-0 p-0 flex justify-center items-center hover:cursor-pointer hover:bg-gray-300 rounded-full"
-          >
+          <div mat-icon-button class="h-6 w-6 min-w-0 p-0 flex justify-center items-center rounded-full">
             <mat-icon>{{ assistantOpen ? 'expand_more' : 'chevron_right' }}</mat-icon>
           </div>
         </div>
         <ng-container *ngIf="assistantOpen">
-          <div>
-            <span translate>adaptationAction.help.help</span>
-            <span class="font-medium text-gray-700">&lt;EMAIL&gt;</span>
-          </div>
-          <div>
-            <span translate>adaptationAction.help.guide</span>:
-            <a
-              class="ms-1 hover:underline text-[#1e5674]"
-              href="https://sinamecc.go.cr/recursos/docs/Gu%C3%ADa%20de%20Registro%20y%20Reporte%20de%20Acciones%20de%20Adaptaci%C3%B3n.pdf"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              https://sinamecc.go.cr/
-            </a>
+          <div class="p-2">
+            <div>
+              <span translate>adaptationAction.help.help</span>
+              <span class="font-medium text-gray-700">&lt;EMAIL&gt;</span>
+            </div>
+            <div>
+              <span translate>adaptationAction.help.guide</span>:
+              <a
+                class="ms-1 hover:underline text-[#1e5674]"
+                href="https://sinamecc.go.cr/recursos/docs/Gu%C3%ADa%20de%20Registro%20y%20Reporte%20de%20Acciones%20de%20Adaptaci%C3%B3n.pdf"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                https://sinamecc.go.cr/
+              </a>
+            </div>
           </div>
         </ng-container>
       </div>

--- a/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.html
+++ b/src/app/adaptation-actions/adaptation-actions-report/adaptation-actions-report.component.html
@@ -232,6 +232,7 @@
             </mat-form-field>
             <input formControlName="adaptationActionLocationOtherCtrl" type="file" />
           </div>
+          <div class="text-sm text-gray-500" translate>adaptationAction.form2.attachGeographicalLocationHint</div>
         </div>
 
         <div class="button-box flex flex-row justify-end items-center">

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -33,6 +33,7 @@ import localeEsCR from '@angular/common/locales/es-CR';
 
 import { MAT_DATE_FORMATS, DateAdapter, MAT_DATE_LOCALE } from '@angular/material/core';
 import { MomentDateAdapter } from '@angular/material-moment-adapter';
+import { Languages } from './i18n/languages';
 
 registerLocaleData(localeEsCR);
 
@@ -83,11 +84,11 @@ export const DATE_FORMATS = {
     },
     {
       provide: LOCALE_ID,
-      useValue: 'es-CR',
+      useValue: Languages.SPANISH,
     },
     {
       provide: MAT_DATE_LOCALE,
-      useValue: 'es-CR',
+      useValue: Languages.SPANISH,
     },
     {
       provide: DateAdapter,

--- a/src/app/auth/login.component.html
+++ b/src/app/auth/login.component.html
@@ -3,16 +3,7 @@
     <img class="logo" src="assets/logo-white.png" alt="angular logo" />
     <div class="flex flex-row justify-center items-center gap-8 my-4">
       <h4 class="version">v{{ version }}</h4>
-      <div class="language-selector">
-        <button mat-raised-button color="primary" [matMenuTriggerFor]="languageMenu">
-          {{ currentLanguage }}
-        </button>
-        <mat-menu #languageMenu="matMenu">
-          <button mat-menu-item *ngFor="let language of languages" (click)="setLanguage(language)">
-            {{ language }}
-          </button>
-        </mat-menu>
-      </div>
+      <app-language-selector></app-language-selector>
     </div>
   </div>
   <div *ngIf="!forgotPassword" class="login-container flex flex-row justify-center">

--- a/src/app/auth/login.component.ts
+++ b/src/app/auth/login.component.ts
@@ -5,7 +5,6 @@ import { finalize, tap } from 'rxjs/operators';
 import { Location } from '@angular/common';
 import { emailRegex } from '@app/utils/regex';
 import { environment } from '@env/environment';
-import { I18nService } from '@app/i18n';
 import { AuthenticationService } from './authentication.service';
 
 @Component({
@@ -28,7 +27,6 @@ export class LoginComponent implements OnInit {
     private location: Location,
     private router: Router,
     private formBuilder: UntypedFormBuilder,
-    private i18nService: I18nService,
     private authenticationService: AuthenticationService,
   ) {
     this.createForm();
@@ -59,10 +57,6 @@ export class LoginComponent implements OnInit {
       .subscribe();
   }
 
-  setLanguage(language: string) {
-    this.i18nService.language = language;
-  }
-
   sendEmailRestarPassword(email: string) {
     this.authenticationService.sendEmailRestarPassword(email).subscribe((response) => {
       this.sendEmail = true;
@@ -72,14 +66,6 @@ export class LoginComponent implements OnInit {
   validateEmail(email: string) {
     const re = emailRegex;
     return re.test(String(email).toLowerCase());
-  }
-
-  get currentLanguage(): string {
-    return this.i18nService.language;
-  }
-
-  get languages(): string[] {
-    return this.i18nService.supportedLanguages;
   }
 
   private createForm() {

--- a/src/app/i18n/i18n.service.ts
+++ b/src/app/i18n/i18n.service.ts
@@ -5,6 +5,7 @@ import { Subscription } from 'rxjs';
 import { Logger } from '@core/logger.service';
 import enUS from '../../translations/en-US.json';
 import esCR from '../../translations/es-CR.json';
+import { Languages } from './languages';
 
 const log = new Logger('I18nService');
 const languageKey = 'language';
@@ -30,8 +31,8 @@ export class I18nService {
 
   constructor(private translateService: TranslateService) {
     // Embed languages to avoid extra HTTP requests
-    translateService.setTranslation('en-US', enUS);
-    translateService.setTranslation('es-CR', esCR);
+    translateService.setTranslation(Languages.ENGLISH, enUS);
+    translateService.setTranslation(Languages.SPANISH, esCR);
   }
 
   /**

--- a/src/app/i18n/language-selector.component.html
+++ b/src/app/i18n/language-selector.component.html
@@ -1,13 +1,14 @@
-<button *ngIf="icon; else text" mat-icon-button [matMenuTriggerFor]="languageMenu">
+<button *ngIf="icon; else text" class="icon-button" mat-icon-button [matMenuTriggerFor]="languageMenu">
   <mat-icon>language</mat-icon>
 </button>
 <ng-template #text>
-  <button mat-raised-button color="primary" [matMenuTriggerFor]="languageMenu">
-    {{ currentLanguage }}
+  <button mat-raised-button color="primary" class="flex flex-row" [matMenuTriggerFor]="languageMenu">
+    <mat-icon>language</mat-icon>
+    <span>{{ language[currentLanguage].name }}</span>
   </button>
 </ng-template>
 <mat-menu #languageMenu="matMenu">
-  <button mat-menu-item *ngFor="let language of languages" (click)="setLanguage(language)">
-    {{ language }}
+  <button mat-menu-item *ngFor="let lang of languages" (click)="setLanguage(lang)">
+    {{ language[lang].flag }} {{ language[lang].name }}
   </button>
 </mat-menu>

--- a/src/app/i18n/language-selector.component.scss
+++ b/src/app/i18n/language-selector.component.scss
@@ -1,0 +1,3 @@
+.icon-button {
+  color: white;
+}

--- a/src/app/i18n/language-selector.component.ts
+++ b/src/app/i18n/language-selector.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, Input } from '@angular/core';
 
 import { I18nService } from './i18n.service';
+import { Languages } from './languages';
 
 @Component({
   selector: 'app-language-selector',
@@ -10,6 +11,17 @@ import { I18nService } from './i18n.service';
 })
 export class LanguageSelectorComponent implements OnInit {
   @Input() icon = false;
+
+  language = {
+    [Languages.SPANISH]: {
+      flag: '🇨🇷',
+      name: 'Español',
+    },
+    [Languages.ENGLISH]: {
+      flag: '🇺🇸',
+      name: 'English',
+    },
+  };
 
   constructor(private i18nService: I18nService) {}
 

--- a/src/app/i18n/languages.ts
+++ b/src/app/i18n/languages.ts
@@ -1,0 +1,4 @@
+export enum Languages {
+  SPANISH = 'es-CR',
+  ENGLISH = 'en-US',
+}

--- a/src/app/shell/shell.component.html
+++ b/src/app/shell/shell.component.html
@@ -25,14 +25,7 @@
         <button *ngIf="showModule(permissions, 'admin')" routerLink="/admin/users" mat-mini-fab color="primary">
           <mat-icon>supervised_user_circle</mat-icon>
         </button>
-        <button class="icon-button" mat-icon-button [matMenuTriggerFor]="languageMenu">
-          <mat-icon>language</mat-icon>
-        </button>
-        <mat-menu #languageMenu="matMenu">
-          <button mat-menu-item *ngFor="let language of languages" (click)="setLanguage(language)">
-            {{ language }}
-          </button>
-        </mat-menu>
+        <app-language-selector [icon]="true"></app-language-selector>
         <div class="user-data">
           <h3 class="mat-h3 no-margin">{{ fullName }}</h3>
           <h3 class="mat-h3">{{ email }}</h3>

--- a/src/app/shell/shell.component.ts
+++ b/src/app/shell/shell.component.ts
@@ -4,7 +4,6 @@ import { MatSidenav } from '@angular/material/sidenav';
 import { Permissions } from '@app/@core/permissions';
 import { AuthenticationService, CredentialsService, Credentials } from '@app/auth';
 import { untilDestroyed } from '@core';
-import { I18nService } from '@app/i18n';
 import { Router } from '@angular/router';
 
 @Component({
@@ -74,7 +73,6 @@ export class ShellComponent implements OnInit, OnDestroy {
     private breakpointObserver: BreakpointObserver,
     private authenticationService: AuthenticationService,
     private credentialsService: CredentialsService,
-    private i18nService: I18nService,
   ) {}
 
   ngOnInit() {
@@ -127,18 +125,6 @@ export class ShellComponent implements OnInit, OnDestroy {
   get email(): string | null {
     const credentials = this.credentialsService.credentials;
     return credentials ? credentials.email : null;
-  }
-
-  get currentLanguage(): string {
-    return this.i18nService.language;
-  }
-
-  get languages(): string[] {
-    return this.i18nService.supportedLanguages;
-  }
-
-  setLanguage(language: string) {
-    this.i18nService.language = language;
   }
 
   logout() {

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -736,6 +736,7 @@
       "AADistrict": "District where the action is executed",
       "narrativeActionPlace": "Narrative description location where the action takes place",
       "attachGeographicalLocation": "Attach the georeferenced location of the action in case you have this",
+      "attachGeographicalLocationHint": "The georeferenced location of the action refers to a GIS point (if possible, allowing the location to be marked on a map), shapes, among others.",
       "categorizationNationalIntruments": "Categorization with national instruments",
       "categorizationNationalIntrumentsTooltip": "For more information on categorization",
       "selectTopic": "Select the topic to which the action belongs",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -422,7 +422,8 @@
     "person": "Person",
     "entity": "Entity",
     "fileUpload": "File upload",
-    "optional": "This section is optional"
+    "optional": "This section is optional",
+    "requiredFile": "File is requried to continue"
   },
 
   "info": {

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -816,7 +816,7 @@
       "impactsAction": "Impacts of the action according to the defined indicators",
       "genderEquity": "The action incorporated elements of gender equity",
       "contributesGenderEquity": "If so, describe how the action contributes to gender equity in the face of climate change",
-      "sustainableDevelopment": "Select the sustainable development goals that most identify with the action",
+      "sustainableDevelopment": "Select the Sustainable Development Goals that were effectively impacted by the action",
       "generatedImpact": "Has the action generated any unwanted/unexpected/negative impact?",
       "annexSupporting": "Attach supporting information associated with the impact of the reported action"
     },

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -116,6 +116,7 @@
     "registeredNonReimbursableCooperationMideplan": "Is the action registered in the Mideplan registry of non-reimbursable international cooperation projects?",
     "financedSourcesInternationalCooperation": "Actions financed with international cooperation sources",
     "referenceYear": "Reference year",
+    "referenceYearHint": "The reference year corresponds to the year in which the budget for the adaptation action is planned.",
     "emissionSourceSector": "Emission source sector",
     "mitigationActionBudget": "Description of the financing source",
     "financingSourceApplying": "Describe the financing source you are applying to",

--- a/src/translations/en-US.json
+++ b/src/translations/en-US.json
@@ -818,6 +818,13 @@
       "sustainableDevelopment": "Select the sustainable development goals that most identify with the action",
       "generatedImpact": "Has the action generated any unwanted/unexpected/negative impact?",
       "annexSupporting": "Attach supporting information associated with the impact of the reported action"
+    },
+    "location": {
+      "national": "Nacional",
+      "provincial": "Provincial",
+      "cantonal": "Cantonal",
+      "district": "District",
+      "other": "Other"
     }
   },
 

--- a/src/translations/es-CR.json
+++ b/src/translations/es-CR.json
@@ -818,6 +818,13 @@
       "sustainableDevelopment": "Seleccione los objetivos de desarrollo sostenible que más se identifican con la acción",
       "generatedImpact": "¿La acción ha generado algún impacto no deseado/inesperado/negativo?",
       "annexSupporting": "Adjunte información de soporte asociada al impacto de la acción reportada"
+    },
+    "location": {
+      "national": "Nacional",
+      "provincial": "Provincial",
+      "cantonal": "Cantonal",
+      "district": "Distrital",
+      "other": "Otro"
     }
   },
 

--- a/src/translations/es-CR.json
+++ b/src/translations/es-CR.json
@@ -816,7 +816,7 @@
       "impactsAction": "Impactos de la acción según los indicadores definidos",
       "genderEquity": "La acción incorporó elementos de equidad de género",
       "contributesGenderEquity": "En caso positivo, describa como la acción aporta a la equidad de género frente al cambio climático",
-      "sustainableDevelopment": "Seleccione los objetivos de desarrollo sostenible que más se identifican con la acción",
+      "sustainableDevelopment": "Seleccione los objetivos de desarrollo sostenible que efectivamente si impactó la acción",
       "generatedImpact": "¿La acción ha generado algún impacto no deseado/inesperado/negativo?",
       "annexSupporting": "Adjunte información de soporte asociada al impacto de la acción reportada"
     },

--- a/src/translations/es-CR.json
+++ b/src/translations/es-CR.json
@@ -116,6 +116,7 @@
     "registeredNonReimbursableCooperationMideplan": "¿Se encuentra la acción registrada en el registro de proyectos de cooperación internacional no reembolsable de Mideplan?",
     "financedSourcesInternationalCooperation": "Acciones financiadas con fuentes de cooperación internacional",
     "referenceYear": "Año de referencia",
+    "referenceYearHint": "El año de referencia corresponde al año donde se tiene presupuestado el monto de la acción de adaptación",
     "emissionSourceSector": "Sector fuente de emisiones",
     "mitigationActionBudget": "Descripción de la fuente de financiamiento",
     "financingSourceApplying": "Describa la fuente financiamiento a la que está aplicando",

--- a/src/translations/es-CR.json
+++ b/src/translations/es-CR.json
@@ -422,7 +422,8 @@
     "person": "Persona",
     "entity": "Entidad",
     "fileUpload": "Subir archivo",
-    "optional": "Esta sección es opcional"
+    "optional": "Esta sección es opcional",
+    "requiredFile": "Es obligatorio subir un archivo para poder continuar"
   },
 
   "info": {

--- a/src/translations/es-CR.json
+++ b/src/translations/es-CR.json
@@ -736,6 +736,7 @@
       "AADistrict": "Distrito donde se ejecuta la acción",
       "narrativeActionPlace": "Descripción narrativa localización donde se desarrolla la acción",
       "attachGeographicalLocation": "Adjunte la localización georeferenciada de la acción en caso de contar con esta",
+      "attachGeographicalLocationHint": "La localización georeferenciada de la acción se refiere a un Punto GIS (de ser posible que se pueda marcar la ubicación en un mapa), shapes, entre otros",
       "categorizationNationalIntruments": "Categorización con instrumentos nacionales",
       "categorizationNationalIntrumentsTooltip": "Para más información sobre la categorización",
       "selectTopic": "Seleccione el tema al que pertenece la acción",


### PR DESCRIPTION
# Summary

This PR includes multiple UX improvements and content adjustments in the adaptation actions form to improve clarity, ensure accurate data input, and fix navigation bugs.

***Fixes # [SIN-I103](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I103/description)***
***Fixes # [SIN-I100](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I100/description)***
***Fixes # [SIN-I111](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I111/description)***
***Fixes # [SIN-I112](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I112/description)***
***Fixes # [SIN-I113](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I113/description)***
***Fixes # [SIN-I114](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I114/description)***
***Fixes # [SIN-I116](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I116/description)***

BE related https://github.com/Sinamecc/sinamecc-backend/pull/142

## Description

* Made the **georeferenced location field optional** and added a clarification note explaining acceptable formats (e.g., GIS point, shapefile).
* Added a **note to field 3.1.5 (Reference Year)** clarifying it refers to the year with allocated adaptation budget.
* Updated **geographic coverage options** in 4.1.7 to: Nacional, Provincial, Cantonal, Distrital, Otro.
* Added a **mandatory file upload note** to 5.2.6 for monitoring support documentation.
* Fixed a **bug in subsection 6.2** where the Next button was not enabled after completion.
* Renamed 6.1.4 to reflect that only SDGs actually impacted by the action should be selected.
* Improved the **language selector on the login screen** to be more intuitive.
* Added a **clarification note to subsection 2.5 (Climate Profile)** referencing the official SINAMECC adaptation reporting guide.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] This change requires a documentation update

Note: BE needs to accept new types for the location type, related to [this issue](https://sprints.zoho.com/workspace/grupoinco#P232/itemdetails/I111/description)   
```indicator.geographic_coverage```

## Evidence

<img width="573" height="370" alt="Screenshot 2025-07-24 at 16 23 47" src="https://github.com/user-attachments/assets/b9bd1eec-5b8b-499f-8585-bd747ff74d23" />

<img width="573" height="370" alt="Screenshot 2025-07-24 at 16 24 07" src="https://github.com/user-attachments/assets/74c025c5-3698-4cb4-96b7-1afbf2933a94" />

<img width="853" height="370" alt="Screenshot 2025-07-24 at 16 24 49" src="https://github.com/user-attachments/assets/57a50c52-c22a-4657-acd9-546b5caed975" />

<img width="853" height="222" alt="Screenshot 2025-07-24 at 16 25 15" src="https://github.com/user-attachments/assets/93a3afdb-73c9-4da4-831d-a22c9dede61c" />

<img width="853" height="222" alt="Screenshot 2025-07-24 at 16 25 48" src="https://github.com/user-attachments/assets/c9f44691-390f-41df-ad8f-16602364e474" />

<img width="853" height="222" alt="Screenshot 2025-07-24 at 16 26 22" src="https://github.com/user-attachments/assets/769fe5dc-e70a-4338-b41a-11c690788132" />

<img width="853" height="222" alt="Screenshot 2025-07-24 at 16 26 49" src="https://github.com/user-attachments/assets/ff8ebd0b-50fc-4974-a188-04c678e933e8" />

<img width="853" height="222" alt="Screenshot 2025-07-24 at 16 27 27" src="https://github.com/user-attachments/assets/e24c7409-5e0b-4685-9042-77cfa6afbcfd" />







