### PR TITLE
Fix: missing is_active in user payload

### DIFF
--- a/src/app/admin/Users/admin-new/admin-new.component.ts
+++ b/src/app/admin/Users/admin-new/admin-new.component.ts
@@ -167,7 +167,10 @@ export class AdminNewComponent implements OnInit {
     delete this.createUserForm.value.roles;
 
     this.adminService
-      .submitUser(this.createUserForm.value)
+      .submitUser({
+        ...this.createUserForm.value,
+        is_active: true,
+      })
       .pipe(
         map((body: any) => {
           const userId = body.body.id;

--- a/src/app/admin/admin.service.ts
+++ b/src/app/admin/admin.service.ts
@@ -212,6 +212,7 @@ export class AdminService {
     formData.append('email', context.email);
     formData.append('first_name', context.name);
     formData.append('last_name', context.lastName);
+    formData.append('is_active', context.is_active);
     formData.append('status', 'created');
 
     return this.httpClient.post(routes.users(), formData, {}).pipe(


### PR DESCRIPTION
# Summary

Added the `is_active` field to the user creation payload to ensure newly created users are active by default.

## Description

* Updated `admin-new.component.ts` to include `is_active: true` when submitting a new user.
* Modified `admin.service.ts` to append `is_active` to the `FormData` payload.
* This fixes cases where users were created without an active status.

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## Evidence

Verified new user creation request includes `is_active: true` and user is now active after creation.

<img width="419" height="188" alt="Screenshot 2025-10-23 at 08 16 57" src="https://github.com/user-attachments/assets/e6e58b09-0085-4323-a3e9-c3c3a904a2dd" />


https://github.com/user-attachments/assets/cf63397c-0f74-45fe-a24f-a45d59290cb7


